### PR TITLE
support Iris driver

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -139,9 +139,20 @@ LOCAL_C_INCLUDES += \
 	$(LOCAL_PATH)/common/compositor/vk \
 	$(LOCAL_PATH)/../mesa/include
 else
+
+# iris driver flags
+ifneq ($(filter iris, $(BOARD_GPU_DRIVERS)),)
+$(warning "Iris driver not fully supported, instability or lower performance may occur!")
+LOCAL_CPPFLAGS += \
+	-DUSE_GL \
+	-DDISABLE_EXPLICIT_SYNC
+else
+# i965 driver flags
 LOCAL_CPPFLAGS += \
 	-DUSE_GL \
 	-DENABLE_RBC
+endif
+
 endif
 
 ifneq ($(strip $(HWC_DISABLE_VA_DRIVER)), true)

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -135,6 +135,12 @@ HWC2::Error IAHWC2::Init() {
   char value[PROPERTY_VALUE_MAX];
   property_get("board.disable.explicit.sync", value, "0");
   disable_explicit_sync_ = atoi(value);
+
+  /* Build wants to explicitly disable sync. */
+#ifdef DISABLE_EXPLICIT_SYNC
+  disable_explicit_sync_ = true;
+#endif
+
   if (disable_explicit_sync_)
     ALOGI("EXPLICIT SYNC support is disabled");
   else


### PR DESCRIPTION
Patch forces compositor to disable sync if this was explicitly wanted
during build since setting property 'board.disable.explicit.sync' does
not work as expected.

Jira: None
Test: Compile and run sucessfully with Iris driver on Android.
Signed-off-by: Tapani Pälli <tapani.palli@intel.com>