### PR TITLE
Fix klocwork issues in GFX domain

### DIFF
--- a/common/compositor/gl/glprogram.cpp
+++ b/common/compositor/gl/glprogram.cpp
@@ -301,6 +301,7 @@ GLProgram::GLProgram()
       alpha_loc_(0),
       premult_loc_(0),
       tex_matrix_loc_(0),
+      solid_color_loc_(0),
       initialized_(false) {
 }
 

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -399,9 +399,9 @@ void GpuDevice::ParseLogicalDisplaySetting(
   if (logical_split_str.empty() ||
       logical_split_str.find_first_not_of("0123456789") != std::string::npos)
     return;
-  uint32_t physical_index = atoi(physical_index_str.c_str());
-  if (physical_index < 0)
+  if (physical_index_str.length() > 1)
     return;
+  uint32_t physical_index = atoi(physical_index_str.c_str());
   uint32_t logical_split_num = atoi(logical_split_str.c_str());
   if (logical_split_num <= 1)
     return;


### PR DESCRIPTION
Revert an old fix because it dosen't pass kw scan.
Add a normal initialization statement.
Add a if statement to validate the variable.
