### PR TITLE
Need to check if plane is reserved before setting All Cilent for KVM

### DIFF
--- a/hwc_display.kvm.ini
+++ b/hwc_display.kvm.ini
@@ -4,7 +4,7 @@ LOGICAL="false"
 MOSAIC="false"
 CLONE="true"
 FLOAT="false"
-PLANE_RESERVED="true"
+PLANE_RESERVED="false"
 ROTATION="false"
 
 # The Order of Physical Displays. This along with connection status

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -1024,7 +1024,7 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
       if (!avail_planes--)
         break;
 #ifdef KVM_HWC_PROPERTY
-      if (IsKvmPlatform())
+      if (IsKvmPlatform() && GpuDevice::getInstance().IsReservedDrmPlane())
         break;
 #endif
       if (layers_[l.second].sf_type() == HWC2::Composition::SolidColor) {


### PR DESCRIPTION
When "Plane Reserve" is not used. No need to set all layer as Client.

Change-Id: I1e517c73c73cf64823bfd04040e1f27cdc4f0726
Tests: None
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>