### PR TITLE
Disable RBC

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -140,8 +140,8 @@ LOCAL_C_INCLUDES += \
 	$(LOCAL_PATH)/../mesa/include
 else
 LOCAL_CPPFLAGS += \
-	-DUSE_GL \
-	-DENABLE_RBC
+	-DUSE_GL
+#	-DENABLE_RBC
 endif
 
 ifneq ($(strip $(HWC_DISABLE_VA_DRIVER)), true)


### PR DESCRIPTION
On clk, if connect two displays, 4K as primary display. The RBC
will cause 4K display stuck.
Disable RBC temporary as this issue block feature.

Test: 4K display works well, do not have other issue.
Tracked-On:https://jira.devtools.intel.com/browse/OAM-80004
Signed-off-by: HeYue <yue.he@intel.com>