### PR TITLE
Revert "Filter EDIP for prefer and performance config"

### DIFF
--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -345,64 +345,6 @@ bool DrmDisplay::GetDisplayAttribute(uint32_t config /*config*/,
   return status;
 }
 
-uint32_t DrmDisplay::FindPreferedDisplayMode(size_t modes_size) {
-  uint32_t prefer_display_mode = 0;
-  if (modes_size > 1) {
-    SPIN_LOCK(display_lock_);
-    for (size_t i = 0; i < modes_size; i++) {
-      // There is only one preferred mode per connector.
-      if (modes_[i].type & DRM_MODE_TYPE_PREFERRED) {
-        prefer_display_mode = i;
-        IHOTPLUGEVENTTRACE("Preferred display config is found. index: %d", i);
-        break;
-      }
-    }
-    SPIN_UNLOCK(display_lock_);
-  }
-  if (prefer_display_mode_ != prefer_display_mode)
-    prefer_display_mode_ = prefer_display_mode;
-  return prefer_display_mode;
-}
-
-uint32_t DrmDisplay::FindPerformaceDisplayMode(size_t modes_size) {
-  uint32_t perf_display_mode;
-  perf_display_mode = prefer_display_mode_;
-  if (modes_size >= prefer_display_mode_) {
-    int32_t prefer_width = 0, prefer_height = 0, prefer_interval = 0;
-    int32_t perf_width = 0, perf_height = 0, perf_interval = 0,
-            previous_perf_interval = 0;
-    GetDisplayAttribute(prefer_display_mode_, HWCDisplayAttribute::kWidth,
-                        &prefer_width);
-    GetDisplayAttribute(prefer_display_mode_, HWCDisplayAttribute::kHeight,
-                        &prefer_height);
-    GetDisplayAttribute(prefer_display_mode_, HWCDisplayAttribute::kRefreshRate,
-                        &prefer_interval);
-    previous_perf_interval = prefer_interval;
-    IHOTPLUGEVENTTRACE("Preferred width:%d, height:%d, interval:%d",
-                       prefer_width, prefer_height, prefer_interval);
-    for (size_t i = 0; i < modes_size; i++) {
-      if (i != prefer_display_mode_) {
-        GetDisplayAttribute(i, HWCDisplayAttribute::kWidth, &perf_width);
-        GetDisplayAttribute(i, HWCDisplayAttribute::kHeight, &perf_height);
-        GetDisplayAttribute(i, HWCDisplayAttribute::kRefreshRate,
-                            &perf_interval);
-        IHOTPLUGEVENTTRACE("EDIP item width:%d, height:%d, rate:%d", perf_width,
-                           perf_height, perf_interval);
-        if (prefer_width == perf_width && prefer_height == perf_height &&
-            prefer_interval > perf_interval &&
-            previous_perf_interval > perf_interval) {
-          perf_display_mode = i;
-          previous_perf_interval = perf_interval;
-        }
-      }
-    }
-  }
-  if (perf_display_mode_ != perf_display_mode)
-    perf_display_mode_ = perf_display_mode;
-  IHOTPLUGEVENTTRACE("PerformaceDisplayMode: %d", perf_display_mode_);
-  return perf_display_mode;
-}
-
 bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
   if (!num_configs)
     return false;
@@ -415,16 +357,8 @@ bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
     return PhysicalDisplay::GetDisplayConfigs(num_configs, configs);
   }
 
-  uint32_t prefer_display_mode = prefer_display_mode_;
-  uint32_t perf_display_mode = perf_display_mode_;
-
   if (!configs) {
-    prefer_display_mode = FindPreferedDisplayMode(modes_size);
-    perf_display_mode = FindPerformaceDisplayMode(modes_size);
-    if (prefer_display_mode == perf_display_mode)
-      *num_configs = 1;
-    else
-      *num_configs = 2;
+    *num_configs = modes_size;
     IHOTPLUGEVENTTRACE(
         "GetDisplayConfigs: Total Configs: %d pipe: %d display: %p",
         *num_configs, pipe_, this);
@@ -435,9 +369,9 @@ bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
       "GetDisplayConfigs: Populating Configs: %d pipe: %d display: %p",
       *num_configs, pipe_, this);
 
-  configs[0] = prefer_display_mode;
-  if (prefer_display_mode != perf_display_mode)
-    configs[1] = perf_display_mode;
+  uint32_t size = *num_configs > modes_size ? modes_size : *num_configs;
+  for (uint32_t i = 0; i < size; i++)
+    configs[i] = i;
 
   return true;
 }

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -173,9 +173,6 @@ class DrmDisplay : public PhysicalDisplay {
 
   void TraceFirstCommit();
 
-  uint32_t FindPreferedDisplayMode(size_t modes_size);
-  uint32_t FindPerformaceDisplayMode(size_t modes_size);
-
   uint32_t crtc_id_ = 0;
   uint32_t mmWidth_ = 0;
   uint32_t mmHeight_ = 0;
@@ -203,8 +200,6 @@ class DrmDisplay : public PhysicalDisplay {
   uint32_t flags_ = DRM_MODE_ATOMIC_ALLOW_MODESET;
   bool planes_updated_ = false;
   bool first_commit_ = false;
-  uint32_t prefer_display_mode_ = 0;
-  uint32_t perf_display_mode_ = 0;
   std::string display_name_ = "";
   HWCContentProtection current_protection_support_ =
       HWCContentProtection::kUnSupported;


### PR DESCRIPTION
Since dynamic fresh rate is an important feature in R.
so remove the filter for reporting all EDID to SF.
This reverts commit 76371ee21f6c44f43f129e06bf63955e49a736d0.

Change-Id: Ib8a2792f2d556c2b671b0bb32f89cb9478c9b743
Tests: WIP
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>