### PR TITLE
Filter EDID for prefer and performance when all EDID is not set

### DIFF
--- a/common/utils/hwcutils.cpp
+++ b/common/utils/hwcutils.cpp
@@ -172,6 +172,20 @@ bool IsKvmPlatform() {
 }
 #endif
 
+bool IsEdidFilting() {
+  const char* key = ALL_EDID_FLAG_PROPERTY;
+  char* value = new char[20];
+  const char* property_true = "1";
+  int len = property_get(key, value, "0");
+  if (len > 0 && strcmp(value, property_true) == 0) {
+    delete[] value;
+    return false;
+  } else {
+    delete[] value;
+    return true;
+  }
+}
+
 std::string StringifyRect(HwcRect<int> rect) {
   std::stringstream ss;
   ss << "{(" << rect.left << "," << rect.top << ") "

--- a/public/hwcutils.h
+++ b/public/hwcutils.h
@@ -25,6 +25,8 @@
 #include <sstream>
 #include "overlaylayer.h"
 
+#define ALL_EDID_FLAG_PROPERTY "vendor.hwcomposer.edid.all"
+
 namespace hwcomposer {
 
 /**
@@ -96,6 +98,11 @@ uint32_t GetTotalPlanesForFormat(uint32_t format);
  */
 bool IsKvmPlatform();
 #endif
+
+/**
+ * Check if need to send all EDID, or only preferred and perf
+ */
+bool IsEdidFilting();
 
 /**
  * Check if two rectangles overlap

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -345,6 +345,64 @@ bool DrmDisplay::GetDisplayAttribute(uint32_t config /*config*/,
   return status;
 }
 
+uint32_t DrmDisplay::FindPreferedDisplayMode(size_t modes_size) {
+  uint32_t prefer_display_mode = 0;
+  if (modes_size > 1) {
+    SPIN_LOCK(display_lock_);
+    for (size_t i = 0; i < modes_size; i++) {
+      // There is only one preferred mode per connector.
+      if (modes_[i].type & DRM_MODE_TYPE_PREFERRED) {
+        prefer_display_mode = i;
+        IHOTPLUGEVENTTRACE("Preferred display config is found. index: %d", i);
+        break;
+      }
+    }
+    SPIN_UNLOCK(display_lock_);
+  }
+  if (prefer_display_mode_ != prefer_display_mode)
+    prefer_display_mode_ = prefer_display_mode;
+  return prefer_display_mode;
+}
+
+uint32_t DrmDisplay::FindPerformaceDisplayMode(size_t modes_size) {
+  uint32_t perf_display_mode;
+  perf_display_mode = prefer_display_mode_;
+  if (modes_size >= prefer_display_mode_) {
+    int32_t prefer_width = 0, prefer_height = 0, prefer_interval = 0;
+    int32_t perf_width = 0, perf_height = 0, perf_interval = 0,
+            previous_perf_interval = 0;
+    GetDisplayAttribute(prefer_display_mode_, HWCDisplayAttribute::kWidth,
+                        &prefer_width);
+    GetDisplayAttribute(prefer_display_mode_, HWCDisplayAttribute::kHeight,
+                        &prefer_height);
+    GetDisplayAttribute(prefer_display_mode_, HWCDisplayAttribute::kRefreshRate,
+                        &prefer_interval);
+    previous_perf_interval = prefer_interval;
+    IHOTPLUGEVENTTRACE("Preferred width:%d, height:%d, interval:%d",
+                       prefer_width, prefer_height, prefer_interval);
+    for (size_t i = 0; i < modes_size; i++) {
+      if (i != prefer_display_mode_) {
+        GetDisplayAttribute(i, HWCDisplayAttribute::kWidth, &perf_width);
+        GetDisplayAttribute(i, HWCDisplayAttribute::kHeight, &perf_height);
+        GetDisplayAttribute(i, HWCDisplayAttribute::kRefreshRate,
+                            &perf_interval);
+        IHOTPLUGEVENTTRACE("EDIP item width:%d, height:%d, rate:%d", perf_width,
+                           perf_height, perf_interval);
+        if (prefer_width == perf_width && prefer_height == perf_height &&
+            prefer_interval > perf_interval &&
+            previous_perf_interval > perf_interval) {
+          perf_display_mode = i;
+          previous_perf_interval = perf_interval;
+        }
+      }
+    }
+  }
+  if (perf_display_mode_ != perf_display_mode)
+    perf_display_mode_ = perf_display_mode;
+  IHOTPLUGEVENTTRACE("PerformaceDisplayMode: %d", perf_display_mode_);
+  return perf_display_mode;
+}
+
 bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
   if (!num_configs)
     return false;
@@ -357,8 +415,22 @@ bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
     return PhysicalDisplay::GetDisplayConfigs(num_configs, configs);
   }
 
+  uint32_t prefer_display_mode = prefer_display_mode_;
+  uint32_t perf_display_mode = perf_display_mode_;
+
+  bool need_filter = IsEdidFilting();
+
   if (!configs) {
-    *num_configs = modes_size;
+    if (need_filter) {
+      prefer_display_mode = FindPreferedDisplayMode(modes_size);
+      perf_display_mode = FindPerformaceDisplayMode(modes_size);
+      if (prefer_display_mode == perf_display_mode)
+        *num_configs = 1;
+      else
+        *num_configs = 2;
+    } else {
+      *num_configs = modes_size;
+    }
     IHOTPLUGEVENTTRACE(
         "GetDisplayConfigs: Total Configs: %d pipe: %d display: %p",
         *num_configs, pipe_, this);
@@ -368,11 +440,15 @@ bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
   IHOTPLUGEVENTTRACE(
       "GetDisplayConfigs: Populating Configs: %d pipe: %d display: %p",
       *num_configs, pipe_, this);
-
-  uint32_t size = *num_configs > modes_size ? modes_size : *num_configs;
-  for (uint32_t i = 0; i < size; i++)
-    configs[i] = i;
-
+  if (need_filter) {
+    configs[0] = prefer_display_mode;
+    if (prefer_display_mode != perf_display_mode)
+      configs[1] = perf_display_mode;
+  } else {
+    uint32_t size = *num_configs > modes_size ? modes_size : *num_configs;
+    for (uint32_t i = 0; i < size; i++)
+      configs[i] = i;
+  }
   return true;
 }
 

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -173,6 +173,9 @@ class DrmDisplay : public PhysicalDisplay {
 
   void TraceFirstCommit();
 
+  uint32_t FindPreferedDisplayMode(size_t modes_size);
+  uint32_t FindPerformaceDisplayMode(size_t modes_size);
+
   uint32_t crtc_id_ = 0;
   uint32_t mmWidth_ = 0;
   uint32_t mmHeight_ = 0;
@@ -200,6 +203,8 @@ class DrmDisplay : public PhysicalDisplay {
   uint32_t flags_ = DRM_MODE_ATOMIC_ALLOW_MODESET;
   bool planes_updated_ = false;
   bool first_commit_ = false;
+  uint32_t prefer_display_mode_ = 0;
+  uint32_t perf_display_mode_ = 0;
   std::string display_name_ = "";
   HWCContentProtection current_protection_support_ =
       HWCContentProtection::kUnSupported;


### PR DESCRIPTION
When ALL EDID flag is not set. send all EDIDs to SF.
When it is set, only send preferred and better performance EDID.

Change-Id: Id325821db3d2602f4e310ad61e8d2d5d9c8513f6
Tests: Work on KBL CIV
Tracked-On: https://jira.devtools.intel.com/browse/OAM-91067
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>