### PR TITLE
Rename hwcomposer target to "celadon"

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -24,7 +24,12 @@ LOCAL_WHOLE_STATIC_LIBRARIES := \
 	libhwcomposer_common \
 	libhwcomposer_wsi
 
+ifeq ($(strip $(TARGET_GFX_INTEL)), intel)
+LOCAL_MODULE := hwcomposer.$(TARGET_GFX_INTEL)
+else
 LOCAL_MODULE := hwcomposer.$(TARGET_BOARD_PLATFORM)
+endif
+
 LOCAL_MODULE_TAGS := optional
 # Preffered paths for all vendor hals /vendor/lib/hw
 LOCAL_PROPRIETARY_MODULE := true


### PR DESCRIPTION
This is to help rename hwcomposer library name from
"TARGET_BOARD_PLATFORM" to "TARGET_GFX_INTEL".

Tracked-On: OAM-93101
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>