### PR TITLE
Check if call_back is null

### DIFF
--- a/common/display/vblankeventhandler.cpp
+++ b/common/display/vblankeventhandler.cpp
@@ -26,9 +26,6 @@ namespace hwcomposer {
 
 static const int64_t kOneSecondNs = 1 * 1000 * 1000 * 1000;
 
-#define VPERIOD75HZ 13333333
-#define VPERIOD90HZ 11111111
-
 VblankEventHandler::VblankEventHandler(DisplayQueue* queue)
     : HWCThread(-8, "VblankEventHandler"),
       display_(0),
@@ -114,10 +111,14 @@ void VblankEventHandler::HandlePageFlipEvent(unsigned int sec,
                       timestamp);
   spin_lock_.lock();
   if (enabled_ && callback_) {
-    if ((abs(vperiod - vperiod_) > (VPERIOD75HZ - VPERIOD90HZ)) &&
-        previous_timestamp_ != -1)
+    if ((abs(vperiod - vperiod_) > VBLANK_THRESHHOLD) &&
+        previous_timestamp_ != -1 && NULL != callback_2_4_) {
+      ITRACE(
+          "Invoking 2.4 new Vsync API, because vsnc blank is changed from %ld "
+          "to %ld",
+          vperiod_, vperiod);
       callback_2_4_->Callback(display_, timestamp, vperiod);
-    else
+    } else
       callback_->Callback(display_, timestamp);
   }
   vperiod_ = vperiod;

--- a/common/display/vblankeventhandler.h
+++ b/common/display/vblankeventhandler.h
@@ -27,6 +27,8 @@
 
 #include "hwcthread.h"
 
+#define VBLANK_THRESHHOLD 2777777
+
 namespace hwcomposer {
 
 class DisplayQueue;


### PR DESCRIPTION
Before invoking check if the call_back is registered or not NULL.
also change the threadhold from 75~90hz(2.22ms) to 90~120hz(2.78ms)
2.22ms is not stable.

Tracked-On: OAM-94449
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
Change-Id: Ibb6cd450368836b4a3c3f7f096ae01ed5feeb9e2