### PR TITLE
Skip the null buffer if it is not solidColor

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -1238,6 +1238,10 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerBuffer(buffer_handle_t buffer,
       sf_type_ == HWC2::Composition::Sideband)
     return HWC2::Error::None;
 
+  if (!(sf_type_ == HWC2::Composition::SolidColor || buffer)) {
+    return HWC2::Error::None;
+  }
+
   native_handle_.handle_ = buffer;
   hwc_layer_.SetNativeHandle(&native_handle_);
 


### PR DESCRIPTION
When the buffer is null and the layer is not SolidColor.
Skip it.

Tracked-On: OAM-95474
Change-Id: Iced17f43ac5a72ba4d1978e72942345890db2427
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>