### PR TITLE
Keep cursor as Device when Cursor plane is available

### DIFF
--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -88,6 +88,10 @@ class DisplayPlaneManager {
     return total_overlays_;
   }
 
+  bool HasCursorPlane() const {
+    return cursor_plane_ != NULL;
+  }
+
   // Transform to be applied to all planes associated
   // with pipe of this displayplanemanager.
   void SetDisplayTransform(uint32_t transform);

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -151,6 +151,13 @@ class DisplayQueue {
       return 0;
   }
 
+  bool HasCursorPlane() const {
+    if (display_plane_manager_)
+      return display_plane_manager_->HasCursorPlane();
+    else
+      return false;
+  }
+
   void ReleaseUnreservedPlanes(std::vector<uint32_t>& reserved_planes);
   void DumpCurrentDisplayPlaneList(DisplayPlaneStateList& composition);
 

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -713,6 +713,8 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
   uint32_t client_z_order = 0;
   bool use_cursor_layer = false;
   bool use_overlay_compose = false;
+  bool has_cursor_plane =
+      display_->HasCursorPlane() && (!(GpuDevice::getInstance().IsGvtActive()));
   uint32_t cursor_z_order = 0;
   IAHWC2::Hwc2Layer *cursor_layer;
   *retire_fence = -1;
@@ -793,7 +795,7 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
     } else if (client_z_order > cursor_z_order) {
       cursor_z_order = client_z_order + 1;
     }
-    if (use_overlay_compose) {
+    if (use_overlay_compose && has_cursor_plane) {
       z_map.emplace(std::make_pair(cursor_z_order, cursor_layer));
       ICOMPOSITORTRACE("Add Cursor HWC2Layer[%d]", cursor_z_order);
     }
@@ -1020,6 +1022,8 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
   int layer_id = 1;
   int Display_Composite_layers;
   int avail_planes = display_->GetTotalOverlays();
+  bool has_cursor_plane =
+      display_->HasCursorPlane() && (!(GpuDevice::getInstance().IsGvtActive()));
   bool include_video_layer = false;
   bool force_all_device_type = false;
 
@@ -1074,14 +1078,17 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
     }
   } else {
     for (std::pair<const hwc2_layer_t, IAHWC2::Hwc2Layer> &l : layers_)
-      l.second.set_validated_type(HWC2::Composition::Invalid);
+      if (!(has_cursor_plane && l.second.IsCursorLayer()))
+        l.second.set_validated_type(HWC2::Composition::Invalid);
 
     for (std::pair<const hwc2_layer_t, IAHWC2::Hwc2Layer> &l : layers_) {
-      if (l.second.sf_type() == HWC2::Composition::Device ||
-          l.second.sf_type() == HWC2::Composition::SolidColor)
-        z_map.emplace(std::make_pair(l.second.z_order(), l.first));
-      else
-        l.second.set_validated_type(HWC2::Composition::Client);
+      if (!(has_cursor_plane && l.second.IsCursorLayer())) {
+        if (l.second.sf_type() == HWC2::Composition::Device ||
+            l.second.sf_type() == HWC2::Composition::SolidColor)
+          z_map.emplace(std::make_pair(l.second.z_order(), l.first));
+        else
+          l.second.set_validated_type(HWC2::Composition::Client);
+      }
     }
 
     /*

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -465,6 +465,10 @@ class NativeDisplay {
     return 0;
   }
 
+  virtual bool HasCursorPlane() const {
+    return false;
+  }
+
  protected:
   friend class PhysicalDisplay;
   friend class GpuDevice;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -665,6 +665,10 @@ int PhysicalDisplay::GetTotalOverlays() const {
     return 0;
 }
 
+bool PhysicalDisplay::HasCursorPlane() const {
+  return display_queue_->HasCursorPlane();
+}
+
 bool PhysicalDisplay::IsBypassClientCTM() const {
   return bypassClientCTM_;
 }

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -267,6 +267,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
 
   int GetTotalOverlays() const override;
 
+  bool HasCursorPlane() const override;
+
  private:
   bool UpdatePowerMode();
   void RefreshClones();


### PR DESCRIPTION
When Client is used, cursor should not be mark as client if
cursor plane is available.
Only add cursor layer when the Cursor plane is available,
otherwise, compose it in Clent. and avoid to add the Client-
composed cursor again

Change-Id: I9b02cd8e6f8d585293f9079161e2be58a288c2da
Tracked-On: OAM-95478
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>