### PR TITLE
Call 2.4 vsync when it is registed

### DIFF
--- a/common/display/vblankeventhandler.cpp
+++ b/common/display/vblankeventhandler.cpp
@@ -110,9 +110,8 @@ void VblankEventHandler::HandlePageFlipEvent(unsigned int sec,
   IPAGEFLIPEVENTTRACE("Callback called from HandlePageFlipEvent. %lu",
                       timestamp);
   spin_lock_.lock();
-  if (enabled_ && callback_) {
-    if ((abs(vperiod - vperiod_) > VBLANK_THRESHHOLD) &&
-        previous_timestamp_ != -1 && NULL != callback_2_4_) {
+  if (enabled_ && (callback_ || callback_2_4_)) {
+    if (NULL != callback_2_4_) {
       ITRACE(
           "Invoking 2.4 new Vsync API, because vsnc blank is changed from %ld "
           "to %ld",

--- a/common/display/vblankeventhandler.h
+++ b/common/display/vblankeventhandler.h
@@ -27,8 +27,6 @@
 
 #include "hwcthread.h"
 
-#define VBLANK_THRESHHOLD 2777777
-
 namespace hwcomposer {
 
 class DisplayQueue;


### PR DESCRIPTION
When 2.4 Vsync is registed, call it.
If it is not, call original Vsync.

Tracked-On: OAM-96446
Change-Id: I391cd96d5c03ef54927bd153d0b646c471d0d5da
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>