### PR TITLE
Fixed the fence fd leak in SetLayerBuffer.

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -1298,10 +1298,15 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerBuffer(buffer_handle_t buffer,
   supported(__func__);
   // The buffer and acquire_fence are handled elsewhere
   if (sf_type_ == HWC2::Composition::Client ||
-      sf_type_ == HWC2::Composition::Sideband)
+      sf_type_ == HWC2::Composition::Sideband) {
+    ALOGD("Skip composition for Client or Sideband layer");
+    close(acquire_fence);
     return HWC2::Error::None;
+  }
 
   if (!(sf_type_ == HWC2::Composition::SolidColor || buffer)) {
+    ALOGD("Skip composition for SolideColor or empty buffer layer.");
+    close(acquire_fence);
     return HWC2::Error::None;
   }
 


### PR DESCRIPTION
Fence fd needs to be closed if it's not going to be used in HWC
composition. This is typically for layer types of Client, Sideband,
SolidColor and layer with NULL buffer attached.

Change-Id: Icd5d5061011a16bae9f5b1062e7aadeedfff3efa
Tracked-On: OAM-96402
Signed-off-by: Wan Shuang <shuang.wan@intel.com>