### PR TITLE
Chang setBrightness API return value to pass VTS

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -1069,7 +1069,7 @@ HWC2::Error IAHWC2::HwcDisplay::SetVsyncEnabled(int32_t enabled) {
 
 HWC2::Error IAHWC2::HwcDisplay::SetDisplayBrightness(float brightness) {
   supported(__func__);
-  return HWC2::Error::None;
+  return HWC2::Error::Unsupported;
 }
 
 HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,


### PR DESCRIPTION
As google expected error::unsupported return when there is no
Display::Brightness capability returned in getDisplayCapabilities API,
make this change to pass VTS test.

Tracked-On: OAM-96695
Signed-Off-By: Liu, Yuanzhe <yuanzhe.liu@intel.com>