### PR TITLE
Rename DRM_FORMAT_NV12_Y_TILED_INTEL

### DIFF
--- a/common/utils/hwcutils.cpp
+++ b/common/utils/hwcutils.cpp
@@ -121,7 +121,7 @@ bool IsSupportedMediaFormat(uint32_t format) {
     case DRM_FORMAT_YVYU:
     case DRM_FORMAT_VYUY:
     case DRM_FORMAT_AYUV:
-    case DRM_FORMAT_NV12_Y_TILED_INTEL:
+    case DRM_FORMAT_NV12_INTEL:
     case DRM_FORMAT_NV21:
     case DRM_FORMAT_YVU420_ANDROID:
       return true;

--- a/os/android/utils_android.h
+++ b/os/android/utils_android.h
@@ -163,7 +163,7 @@ static uint32_t DrmFormatToHALFormat(int format) {
     case DRM_FORMAT_YVU444:
       ETRACE("YUV format using RGB buffer \n");
       return 0;
-    case DRM_FORMAT_NV12_Y_TILED_INTEL:
+    case DRM_FORMAT_NV12_INTEL:
       return HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL;
     case DRM_FORMAT_P010:
       return HAL_PIXEL_FORMAT_P010_INTEL;

--- a/os/platformcommondefines.h
+++ b/os/platformcommondefines.h
@@ -30,7 +30,7 @@ VkFormat NativeToVkFormat(int native_format);
 
 #define DRM_FORMAT_NONE fourcc_code('0', '0', '0', '0')
 
-#define DRM_FORMAT_NV12_Y_TILED_INTEL fourcc_code('9', '9', '9', '6')
+#define DRM_FORMAT_NV12_INTEL fourcc_code('9', '9', '9', '6')
 // minigbm specific DRM_FORMAT_YVU420_ANDROID enum
 #define DRM_FORMAT_YVU420_ANDROID fourcc_code('9', '9', '9', '7')
 

--- a/tests/apps/jsonlayerstest.cpp
+++ b/tests/apps/jsonlayerstest.cpp
@@ -602,7 +602,7 @@ static uint32_t layerformat2gbmformat(LAYER_FORMAT format,
     case LAYER_HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
       *usage_format = LAYER_HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL;
       *usage = hwcomposer::kLayerVideo;
-      return DRM_FORMAT_NV12_Y_TILED_INTEL;
+      return DRM_FORMAT_NV12_INTEL;
     case LAYER_FORMAT_UNDEFINED:
       return (uint32_t)-1;
   }

--- a/tests/apps/linux_frontend_test.cpp
+++ b/tests/apps/linux_frontend_test.cpp
@@ -430,7 +430,7 @@ static uint32_t layerformat2gbmformat(LAYER_FORMAT format,
     case LAYER_HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
       *usage_format = LAYER_HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL;
       *usage = hwcomposer::kLayerVideo;
-      return DRM_FORMAT_NV12_Y_TILED_INTEL;
+      return DRM_FORMAT_NV12_INTEL;
     case LAYER_FORMAT_UNDEFINED:
       return (uint32_t)-1;
   }

--- a/tests/common/videolayerrenderer.cpp
+++ b/tests/common/videolayerrenderer.cpp
@@ -68,7 +68,7 @@ static int get_bpp_from_format(uint32_t format, size_t plane) {
     case DRM_FORMAT_NV16:
     case DRM_FORMAT_NV12:
     case DRM_FORMAT_NV21:
-    case DRM_FORMAT_NV12_Y_TILED_INTEL:
+    case DRM_FORMAT_NV12_INTEL:
       return (plane == 0) ? 8 : 16;
     case DRM_FORMAT_P010:
       return (plane == 0) ? 16 : 32;
@@ -143,7 +143,7 @@ static uint32_t get_linewidth_from_format(uint32_t format, uint32_t width,
       case DRM_FORMAT_P010:
       case DRM_FORMAT_NV21:
       case DRM_FORMAT_NV16:
-      case DRM_FORMAT_NV12_Y_TILED_INTEL:
+      case DRM_FORMAT_NV12_INTEL:
       case DRM_FORMAT_YVU420:
       case DRM_FORMAT_YVU420_ANDROID:
       case DRM_FORMAT_YUV420:
@@ -217,7 +217,7 @@ static uint32_t get_height_from_format(uint32_t format, uint32_t height,
     case DRM_FORMAT_P010:
     case DRM_FORMAT_NV21:
     case DRM_FORMAT_YUV420:
-    case DRM_FORMAT_NV12_Y_TILED_INTEL:
+    case DRM_FORMAT_NV12_INTEL:
       return (plane == 0) ? height : height / 2;
   }
   ETRACE("UNKNOWN FORMAT %d", format);

--- a/wsi/drm/commondrmutils.h
+++ b/wsi/drm/commondrmutils.h
@@ -72,7 +72,7 @@ static size_t drm_bo_get_num_planes(uint32_t format) {
       return 1;
     case DRM_FORMAT_NV12:
     case DRM_FORMAT_NV21:
-    case DRM_FORMAT_NV12_Y_TILED_INTEL:
+    case DRM_FORMAT_NV12_INTEL:
     case DRM_FORMAT_NV16:
     case DRM_FORMAT_P010:
       return 2;

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -79,7 +79,7 @@ DrmBuffer::~DrmBuffer() {
 
 void DrmBuffer::Initialize(const HwcMeta& meta) {
   format_ = meta.format_;
-  if (format_ == DRM_FORMAT_NV12_Y_TILED_INTEL || format_ == DRM_FORMAT_NV21)
+  if (format_ == DRM_FORMAT_NV12_INTEL || format_ == DRM_FORMAT_NV21)
     format_ = DRM_FORMAT_NV12;
   else if (format_ == DRM_FORMAT_YVU420_ANDROID)
     format_ = DRM_FORMAT_YUV420;


### PR DESCRIPTION
Replace DRM_FORMAT_NV12_Y_TILED_INTEL with a more common name DRM_FORMAT_NV12_INTEL.

Tracked-On: OAM-129537